### PR TITLE
Rejig recursive explosion damage processing.

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -387,9 +387,7 @@ public sealed partial class ExplosionSystem
         for (var i = 0; i < _toDamage.Count; i++)
         {
             var (ent, damage) = _toDamage[i];
-
             _containedEntities.Clear();
-
             var ev = new BeforeExplodeEvent(damage, prototype, _containedEntities);
             RaiseLocalEvent(ent, ref ev);
 
@@ -425,7 +423,7 @@ public sealed partial class ExplosionSystem
             GetEntitiesToDamage(uid, originalDamage, id);
             foreach (var (entity, damage) in _toDamage)
             {
-                // TODO EXPLOSIONS turn explosions into entities, and add the origin entity.
+                // TODO EXPLOSIONS turn explosions into entities, and pass the the entity in as the damage origin.
                 _damageableSystem.TryChangeDamage(entity, damage, ignoreResistances: true);
             }
         }

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -51,7 +51,7 @@ public sealed partial class ExplosionSystem
     private int _previousTileIteration;
 
     /// <summary>
-    /// This list is used when raising <see cref="RecursiveExplodeEvent"/> to avoid allocating a new list per event.
+    /// This list is used when raising <see cref="BeforeExplodeEvent"/> to avoid allocating a new list per event.
     /// </summary>
     private readonly List<EntityUid> _containedEntities = new();
 
@@ -390,7 +390,7 @@ public sealed partial class ExplosionSystem
 
             _containedEntities.Clear();
 
-            var ev = new RecursiveExplodeEvent(damage, prototype, _containedEntities);
+            var ev = new BeforeExplodeEvent(damage, prototype, _containedEntities);
             RaiseLocalEvent(ent, ref ev);
 
             if (_containedEntities.Count == 0)

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -55,7 +55,7 @@ namespace Content.Server.Hands.Systems
 
             SubscribeLocalEvent<HandsComponent, ComponentGetState>(GetComponentState);
 
-            SubscribeLocalEvent<HandsComponent, RecursiveExplodeEvent>(OnExploded);
+            SubscribeLocalEvent<HandsComponent, BeforeExplodeEvent>(OnExploded);
 
             CommandBinds.Builder
                 .Bind(ContentKeyFunctions.ThrowItemInHand, new PointerInputCmdHandler(HandleThrowItem))
@@ -76,7 +76,7 @@ namespace Content.Server.Hands.Systems
             args.State = new HandsComponentState(hands);
         }
 
-        private void OnExploded(Entity<HandsComponent> ent, ref RecursiveExplodeEvent args)
+        private void OnExploded(Entity<HandsComponent> ent, ref BeforeExplodeEvent args)
         {
             foreach (var hand in ent.Comp.Hands.Values)
             {

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -55,7 +55,7 @@ namespace Content.Server.Hands.Systems
 
             SubscribeLocalEvent<HandsComponent, ComponentGetState>(GetComponentState);
 
-            SubscribeLocalEvent<HandsComponent, ExplodedEvent>(OnExploded);
+            SubscribeLocalEvent<HandsComponent, RecursiveExplodeEvent>(OnExploded);
 
             CommandBinds.Builder
                 .Bind(ContentKeyFunctions.ThrowItemInHand, new PointerInputCmdHandler(HandleThrowItem))
@@ -76,9 +76,13 @@ namespace Content.Server.Hands.Systems
             args.State = new HandsComponentState(hands);
         }
 
-        private void OnExploded(Entity<HandsComponent> ent, ref ExplodedEvent args)
+        private void OnExploded(Entity<HandsComponent> ent, ref RecursiveExplodeEvent args)
         {
-            args.Contents.AddRange(EnumerateHeld(ent, ent.Comp));
+            foreach (var hand in ent.Comp.Hands.Values)
+            {
+                if (hand.HeldEntity is {} uid)
+                    args.Contents.Add(uid);
+            }
         }
 
         private void OnDisarmed(EntityUid uid, HandsComponent component, DisarmedEvent args)

--- a/Content.Server/Inventory/ServerInventorySystem.cs
+++ b/Content.Server/Inventory/ServerInventorySystem.cs
@@ -16,14 +16,14 @@ namespace Content.Server.Inventory
         {
             base.Initialize();
 
-            SubscribeLocalEvent<InventoryComponent, RecursiveExplodeEvent>(OnExploded);
+            SubscribeLocalEvent<InventoryComponent, BeforeExplodeEvent>(OnExploded);
 
             SubscribeLocalEvent<ClothingComponent, UseInHandEvent>(OnUseInHand);
 
             SubscribeNetworkEvent<OpenSlotStorageNetworkMessage>(OnOpenSlotStorage);
         }
 
-        private void OnExploded(Entity<InventoryComponent> ent, ref RecursiveExplodeEvent args)
+        private void OnExploded(Entity<InventoryComponent> ent, ref BeforeExplodeEvent args)
         {
             if (!TryGetContainerSlotEnumerator(ent, out var slots, ent.Comp))
                 return;

--- a/Content.Server/Inventory/ServerInventorySystem.cs
+++ b/Content.Server/Inventory/ServerInventorySystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Storage;
-using System.Linq;
 
 namespace Content.Server.Inventory
 {
@@ -17,14 +16,14 @@ namespace Content.Server.Inventory
         {
             base.Initialize();
 
-            SubscribeLocalEvent<InventoryComponent, ExplodedEvent>(OnExploded);
+            SubscribeLocalEvent<InventoryComponent, RecursiveExplodeEvent>(OnExploded);
 
             SubscribeLocalEvent<ClothingComponent, UseInHandEvent>(OnUseInHand);
 
             SubscribeNetworkEvent<OpenSlotStorageNetworkMessage>(OnOpenSlotStorage);
         }
 
-        private void OnExploded(Entity<InventoryComponent> ent, ref ExplodedEvent args)
+        private void OnExploded(Entity<InventoryComponent> ent, ref RecursiveExplodeEvent args)
         {
             if (!TryGetContainerSlotEnumerator(ent, out var slots, ent.Comp))
                 return;

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -47,7 +47,7 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
 
         SubscribeLocalEvent<EntityStorageComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<EntityStorageComponent, WeldableAttemptEvent>(OnWeldableAttempt);
-        SubscribeLocalEvent<EntityStorageComponent, RecursiveExplodeEvent>(OnExploded);
+        SubscribeLocalEvent<EntityStorageComponent, BeforeExplodeEvent>(OnExploded);
 
         SubscribeLocalEvent<InsideEntityStorageComponent, InhaleLocationEvent>(OnInsideInhale);
         SubscribeLocalEvent<InsideEntityStorageComponent, ExhaleLocationEvent>(OnInsideExhale);
@@ -100,7 +100,7 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
         }
     }
 
-    private void OnExploded(Entity<EntityStorageComponent> ent, ref RecursiveExplodeEvent args)
+    private void OnExploded(Entity<EntityStorageComponent> ent, ref BeforeExplodeEvent args)
     {
         if (ent.Comp.ExplosionDamageCoefficient <= 0)
             return;

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -47,7 +47,7 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
 
         SubscribeLocalEvent<EntityStorageComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<EntityStorageComponent, WeldableAttemptEvent>(OnWeldableAttempt);
-        SubscribeLocalEvent<EntityStorageComponent, ExplodedEvent>(OnExploded);
+        SubscribeLocalEvent<EntityStorageComponent, RecursiveExplodeEvent>(OnExploded);
 
         SubscribeLocalEvent<InsideEntityStorageComponent, InhaleLocationEvent>(OnInsideInhale);
         SubscribeLocalEvent<InsideEntityStorageComponent, ExhaleLocationEvent>(OnInsideExhale);
@@ -100,11 +100,13 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
         }
     }
 
-    private void OnExploded(Entity<EntityStorageComponent> ent, ref ExplodedEvent args)
+    private void OnExploded(Entity<EntityStorageComponent> ent, ref RecursiveExplodeEvent args)
     {
-        // if the expanding gases cant get inside, they cant explode the contents
-        if (!ent.Comp.Airtight)
-            args.Contents.AddRange(ent.Comp.Contents.ContainedEntities);
+        if (ent.Comp.ExplosionDamageCoefficient <= 0)
+            return;
+
+        args.Contents.AddRange(ent.Comp.Contents.ContainedEntities);
+        args.DamageCoefficient *= ent.Comp.ExplosionDamageCoefficient;
     }
 
     protected override void TakeGas(EntityUid uid, SharedEntityStorageComponent component)

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -28,7 +28,7 @@ public sealed partial class StorageSystem : SharedStorageSystem
         base.Initialize();
         SubscribeLocalEvent<StorageComponent, GetVerbsEvent<ActivationVerb>>(AddUiVerb);
         SubscribeLocalEvent<StorageComponent, BoundUIClosedEvent>(OnBoundUIClosed);
-        SubscribeLocalEvent<StorageComponent, ExplodedEvent>(OnExploded);
+        SubscribeLocalEvent<StorageComponent, RecursiveExplodeEvent>(OnExploded);
 
         SubscribeLocalEvent<StorageFillComponent, MapInitEvent>(OnStorageFillMapInit);
     }
@@ -99,7 +99,7 @@ public sealed partial class StorageSystem : SharedStorageSystem
         }
     }
 
-    private void OnExploded(Entity<StorageComponent> ent, ref ExplodedEvent args)
+    private void OnExploded(Entity<StorageComponent> ent, ref RecursiveExplodeEvent args)
     {
         args.Contents.AddRange(ent.Comp.Container.ContainedEntities);
     }

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -28,7 +28,7 @@ public sealed partial class StorageSystem : SharedStorageSystem
         base.Initialize();
         SubscribeLocalEvent<StorageComponent, GetVerbsEvent<ActivationVerb>>(AddUiVerb);
         SubscribeLocalEvent<StorageComponent, BoundUIClosedEvent>(OnBoundUIClosed);
-        SubscribeLocalEvent<StorageComponent, RecursiveExplodeEvent>(OnExploded);
+        SubscribeLocalEvent<StorageComponent, BeforeExplodeEvent>(OnExploded);
 
         SubscribeLocalEvent<StorageFillComponent, MapInitEvent>(OnStorageFillMapInit);
     }
@@ -99,7 +99,7 @@ public sealed partial class StorageSystem : SharedStorageSystem
         }
     }
 
-    private void OnExploded(Entity<StorageComponent> ent, ref RecursiveExplodeEvent args)
+    private void OnExploded(Entity<StorageComponent> ent, ref BeforeExplodeEvent args)
     {
         args.Contents.AddRange(ent.Comp.Container.ContainedEntities);
     }

--- a/Content.Shared/Explosion/ExplosionEvents.cs
+++ b/Content.Shared/Explosion/ExplosionEvents.cs
@@ -36,14 +36,14 @@ public record struct BeforeExplodeEvent(DamageSpecifier Damage, string Id, List<
     public readonly DamageSpecifier Damage = Damage;
 
     /// <summary>
-    /// Damage multiplier for modifying the damage that will get dealt to contained entities.
-    /// </summary>
-    public float DamageCoefficient = 1;
-
-    /// <summary>
     /// ID of the explosion prototype.
     /// </summary>
     public readonly string Id = Id;
+
+    /// <summary>
+    /// Damage multiplier for modifying the damage that will get dealt to contained entities.
+    /// </summary>
+    public float DamageCoefficient = 1;
 
     /// <summary>
     /// Contained/child entities that should receive recursive explosion damage.

--- a/Content.Shared/Explosion/ExplosionEvents.cs
+++ b/Content.Shared/Explosion/ExplosionEvents.cs
@@ -27,7 +27,7 @@ public record struct GetExplosionResistanceEvent(string ExplosionPrototype) : II
 /// will also receive this event.
 /// </summary>
 [ByRefEvent]
-public record struct RecursiveExplodeEvent(DamageSpecifier Damage, string Id, List<EntityUid> Contents)
+public record struct BeforeExplodeEvent(DamageSpecifier Damage, string Id, List<EntityUid> Contents)
 {
     /// <summary>
     /// The damage that will be received by this entity. Note that the entity's explosion resistance has already been

--- a/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
@@ -124,6 +124,12 @@ public abstract partial class SharedEntityStorageComponent : Component
     /// </summary>
     [ViewVariables]
     public Container Contents = default!;
+
+    /// <summary>
+    /// Multiplier for explosion damage that gets applied to contained entities.
+    /// </summary>
+    [DataField]
+    public float ExplosionDamageCoefficient = 1;
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
I've made a few changes to how the recursive explosion damage processing works. Most notably, I've moved the damage-dealing code back into the explosion system instead of having the event subscription apply damage. It will now always get a list of all entities to damage before ever actually applying any damage. There were a few reasons for this:
- I want to avoid potential ordering issues. E.g., if the damage system handler fires first, it might destroy the entity and empty contained entities before they get added by the storage systems, and thus never dealing damage to them. Ordered event subscriptions could help, but they are also slow and I'd rather not use them.
- Similarly, damaging contained entities may spawn new entities inside of the containers (glass -> shards), which might then get damaged again (effectively dealing double damage).
- I want explosion-resistance to also reduce damage dealt to contained entities, so the damage resistance calculations have to be done outside of the damageable system event handler.

I've also removed the EntityStorage Airtight check, because it effectively makes any airtight storage provide complete explosion immunity again, which was one of the issues that needed to be fixed. I've replaced it with a new datafield that just scales the damage done to contained entities, so its still easy to make a locker provide more protection than a cardboard box.
